### PR TITLE
add option to provide custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ var options = {
     },
     json: true, // Automatically parses the JSON string in the response, 
     retry : 2, // will retry the call twice, in case of error.
+    logger: myLogger, // custom logger with 'info()' and 'debug()' functions, for example log4js logger
     verbose_logging : false, // will log errors only, if set to be true, will log all actions
     accepted: [ 400, 404 ] // Accepted HTTP Status codes (will not retry if request response has any of these HTTP Status Code)
     delay: 2000 // will delay retries by 2000 ms.  The default is 100. 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 const requestPromise = require('request-promise');
 const Promise = require('bluebird');
-const logger = require('./modules/logger')('request-promise-retry');
+
+let logger = require('./modules/logger')('request-promise-retry');
 
 class rpRetry {
     static _rpRetry(options) {
@@ -69,6 +70,10 @@ class rpRetry {
     }
 
     static rp(options) {
+        if (options.logger) {
+            logger = options.logger;
+            delete options.logger;
+        }
         if (options.retry) {
             if (typeof options.retry === 'number') {
                 if (options.retry < 0) {


### PR DESCRIPTION
Sample usage - route to log4js, remap `info` to `warning` and silence debug messages.

```
      logger: {
        info: _.bind(logger.warn, logger),
        debug: _.noop
      }
```